### PR TITLE
Remove extra space from end of SCREENNAME in is_running check

### DIFF
--- a/minebackup.sh
+++ b/minebackup.sh
@@ -112,7 +112,7 @@ function as_user() {
 # 'Check running process' function
 function is_running() {
   [ ${DODEBUG} -eq 1 ] && set -x
-  if ps aux | grep -v grep | grep SCREEN | grep "${SCREENNAME} " >/dev/null 2>&1
+  if ps aux | grep -v grep | grep SCREEN | grep $SCREENNAME >/dev/null 2>&1
   then
     return 0 
   else


### PR DESCRIPTION
I had to make this change in order to get the script to work for me. Not sure why `grep "${SCREENNAME} "` was used instead of `grep $SCREENNAME`, but if there's a good reason feel free to reject this pull request :)

By the way, this is a great script!
