### PR TITLE
Add USER variable to settings file

### DIFF
--- a/minebackup.sh
+++ b/minebackup.sh
@@ -36,6 +36,8 @@ else
   # Create default one
   echo "[INFO] Creating default configuration file $SETTINGS_FILE"
   cat > $SETTINGS_FILE << EOCONF
+# User running screen session
+USER="minecraft"
 # Screen session name
 SCREENNAME="minecraft"
 # Display name of your server


### PR DESCRIPTION
Add USER variable to the default settings file to allow the script to run correctly from CRON.  Tested working under Ubuntu 16.04.6 LTS